### PR TITLE
Only install the PolicyException if the CRD exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only install the PolicyException if the CRD exists.
+
 ## [0.2.0] - 2025-02-25
 
 ### Changed

--- a/helm/kube-vip-cloud-provider/templates/policyexception.yaml
+++ b/helm/kube-vip-cloud-provider/templates/policyexception.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy.giantswarm.io/v1alpha1" -}}
 apiVersion: policy.giantswarm.io/v1alpha1
 kind: PolicyException
 metadata:
@@ -16,3 +17,4 @@ spec:
       - {{ .Release.Namespace | default "kube-system" }}
       names:
       - {{ include "kube-vip-cloud-provider.name" . }}*
+{{- end -}}


### PR DESCRIPTION
This PR:

- makes the polex optional if the cluster doesn't have the polex crd


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
